### PR TITLE
Add PLJMOH Token Metadata (Polygon)

### DIFF
--- a/src/pljmoh.json
+++ b/src/pljmoh.json
@@ -1,0 +1,17 @@
+{
+  "name": "PLJMOH Official Token List",
+  "logoURI": "https://yesoklab.github.io/.well-known/pljmoh.png",
+  "keywords": ["pljmoh", "lee jae myung", "korea", "meme", "politics"],
+  "timestamp": "2025-07-06T00:00:00+09:00",
+  "version": { "major": 1, "minor": 0, "patch": 0 },
+  "tokens": [
+    {
+      "chainId": 137,
+      "address": "0x2Cb13fB3743315691b90Aa0B960d08BcF64F56F3",
+      "symbol": "PLJMOH",
+      "name": "President Lee Jae-myung of Hope",
+      "decimals": 18,
+      "logoURI": "https://yesoklab.github.io/.well-known/pljmoh.png"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the PLJMOH token metadata for Polygon (MATIC) network.

- Token Name: President Lee Jae-myung of Hope (PLJMOH)
- Symbol: PLJMOH
- Chain: Polygon
- Contract: 0x2Cb13fB3743315691b90Aa0B960d08BcF64F56F3
- Website: https://yesoklab.github.io
- Logo: https://yesoklab.github.io/.well-known/pljmoh.png

📘 Description (EN):  
PLJMOH is a symbolic meme token representing the will of Korean citizens to support transparency and democracy through blockchain.

📗 설명 (KR):  
PLJMOH는 이재명 대통령의 1시간을 상징하는 밈 토큰으로, 5천1백만 국민의 시간을 블록체인화한 상징 토큰입니다.
